### PR TITLE
feat(cmd): :sparkles: get Github token from env var GITHUB_TOKEN

### DIFF
--- a/dangling_finder/main.py
+++ b/dangling_finder/main.py
@@ -42,7 +42,7 @@ exclusivity_callback = mutually_exclusive_group()
 def find_lost_pr_heads(
     owner: str,
     repo: str,
-    github_token: Annotated[str, typer.Option()],
+    github_token: Annotated[str, typer.Argument(envvar="GITHUB_TOKEN")],
     bash_script: Annotated[
         bool, typer.Option(callback=exclusivity_callback)
     ] = False,


### PR DESCRIPTION
BREAKING CHANGE: github token is now a command argument, no longer an option